### PR TITLE
Fix build with Dovecot 2.29+

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ fts-elasticsearch is a Dovecot full-text search indexing plugin that uses Elasti
 
 Dovecot communicates to ES using HTTP/JSON queries. It supports automatic indexing and searching of e-mail.
 
-***Note: This project is not currently building against Dovecot 2.2.29 and needs some modification. I have not had time to work on this recently: pull requests are very welcomed otherwise this project will be dormant for a little while.**
-
 ## Requirements
 * Dovecot 2.2+
 * JSON-C

--- a/src/elasticsearch-conn.c
+++ b/src/elasticsearch-conn.c
@@ -84,7 +84,7 @@ int32_t elasticsearch_connection_init(const char *url, bool debug,
     }
 
     conn = i_new(struct elasticsearch_connection, 1);
-    conn->http_host = i_strdup(http_url->host_name);
+    conn->http_host = i_strdup(http_url->host.name);
     conn->http_port = http_url->port;
     conn->http_base_url = i_strconcat(http_url->path, http_url->enc_query, NULL);
     conn->http_ssl = http_url->have_ssl;


### PR DESCRIPTION
This fixes the build for 2.29 (potentially) and 2.3 (version I tested
with). This, however, will most probably break builds for Dovecot <2.29,
although I'm not sure if it's desired to preserve compatibility with
these older versions. If it is, I'd be happy to try to change this, with
some guidance though, since my knowledge of C is quite limited.